### PR TITLE
Make CSS support more robust and flexible

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -6,7 +6,7 @@
 ;; Version: 1.0.5
 ;; Author: Shin Aoyama <smihica@gmail.com>
 ;; URL: https://github.com/smihica/emmet
-;; Last-Updated: 2013-09-16 Mon
+;; Last-Updated: 2014-02-17 Mon
 ;; Keywords: convenience
 
 ;; This file is free software; you can redistribute it and/or modify
@@ -3337,8 +3337,20 @@ tbl))
             (replace-regexp-in-string "\n" (concat "\n" first-col)
                                       (replace-regexp-in-string "    " tab markup)))))
 
+(defvar emmet-use-css-transform nil
+  "When true, transform Emmet snippets into CSS, instead of the usual HTML.")
+(make-variable-buffer-local 'emmet-use-css-transform)
+
+(defvar emmet-css-major-modes
+  '(css-mode
+    scss-mode
+    sass-mode
+    less-mode
+    less-css-mode)
+  "Major modes that use emmet for CSS, rather than HTML.")
+
 (defun emmet-transform (input)
-  (if (memq major-mode '(css-mode scss-mode sass-mode))
+  (if emmet-use-css-transform
       (emmet-css-transform input)
     (emmet-html-transform input)))
 
@@ -3394,6 +3406,11 @@ For more information see `emmet-mode'."
     (define-key emmet-mode-keymap (kbd "C-j") 'emmet-expand-line)
     (define-key emmet-mode-keymap (kbd "<C-return>") 'emmet-expand-line)))
 
+(defun emmet-after-hook ()
+  "Initialize Emmet's buffer-local variables."
+  (if (memq major-mode emmet-css-major-modes)
+      (setq emmet-use-css-transform t)))
+
 ;;;###autoload
 (define-minor-mode emmet-mode
   "Minor mode for writing HTML and CSS markup.
@@ -3416,7 +3433,8 @@ Home page URL `http://www.emacswiki.org/emacs/Emmet'.
 
 See also `emmet-expand-line'."
   :lighter " Emmet"
-  :keymap emmet-mode-keymap)
+  :keymap emmet-mode-keymap
+  :after-hook (emmet-after-hook))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Emmet yasnippet integration


### PR DESCRIPTION
By introducing a few new variables, we make it easier for users to
control whether emmet-mode will generate HTML or CSS.

The new variables are particularly helpful for using emmet-mode in
[web-mode](https://github.com/fxbois/web-mode), where both CSS and HTML
may be present in the same buffer, so major-mode detection is not a
reliable means of deciding whether to generate CSS or HTML.

This should fix issue #14, as well as make it easier for users to handle similar cases themselves.
