### PR TITLE
Fix #23, until a better way is found.

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -3465,6 +3465,14 @@ tbl))
   "Customization group for emmet-mode."
   :group 'convenience)
 
+(defun emmet-check-for-markup (bound)
+  (save-excursion
+    (save-match-data
+      (goto-char (line-beginning-position))
+      (if (re-search-forward "\\(\\([ \t]+\\)?<[^>]*?>\\)+" bound t)
+          t
+        nil))))
+
 (defun emmet-expr-on-line ()
   "Extract a emmet expression and the corresponding bounds
    for the current line."
@@ -3551,7 +3559,9 @@ For more information see `emmet-mode'."
         (if expr
             (let ((markup (emmet-transform (first expr))))
               (when markup
-                (let ((pretty (emmet-prettify markup (current-indentation))))
+                (let ((pretty (if (emmet-check-for-markup here)
+                                  markup
+                                (emmet-prettify markup (current-indentation)))))
                   (when pretty
                     (delete-region (second expr) (third expr))
                     (emmet-insert-and-flash pretty)

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -5,6 +5,14 @@
   "Customization group for emmet-mode."
   :group 'convenience)
 
+(defun emmet-check-for-markup (bound)
+  (save-excursion
+    (save-match-data
+      (goto-char (line-beginning-position))
+      (if (re-search-forward "\\(\\([ \t]+\\)?<[^>]*?>\\)+" bound t)
+          t
+        nil))))
+
 (defun emmet-expr-on-line ()
   "Extract a emmet expression and the corresponding bounds
    for the current line."
@@ -91,7 +99,9 @@ For more information see `emmet-mode'."
         (if expr
             (let ((markup (emmet-transform (first expr))))
               (when markup
-                (let ((pretty (emmet-prettify markup (current-indentation))))
+                (let ((pretty (if (emmet-check-for-markup here)
+                                  markup
+                                (emmet-prettify markup (current-indentation)))))
                   (when pretty
                     (delete-region (second expr) (third expr))
                     (emmet-insert-and-flash pretty)


### PR DESCRIPTION
This isn't great, but should probably be applied for now, since the previous pull request is applied.  It prevents emmet-prettify from running when emmet is called within HTML forms; this prevents extra indentation from being added.

I'm trying to get up to speed on the code, so I can re-implement this stuff in a cleaner manner ;-)
