### PR TITLE
Support for indent-region

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-__This is a fork of [zencoding-mode](https://github.com/rooney/zencoding) to support [Emmet](http://emmet.io/)'s feature.__
+__This is a fork of [zencoding-mode](https://github.com/rooney/zencoding) to support [Emmet](http://emmet.io/)'s feature set.__
 
 ## About zencoding-mode
 
@@ -15,24 +15,22 @@ Zen Coding has been renamed to [Emmet](http://emmet.io/) and includes an expande
 
 ## Installation
 
-### 1. From marmalade
+### 1. From marmalade or MELPA
 
-If your emacs has been installed marmalade then type `M-x package-list-packages` search `emmet-mode X.X.X` and install it.
+If your Emacs has the [marmalade](http://marmalade-repo.org/) or [MELPA](http://melpa.milkbox.net/) package repositories installed, just type `M-x package-list-packages`, search for `emmet-mode`, and install it.
 
-### 1. Manual instalation
+### 1. Manual Installation
 
 Just make sure emmet-mode.el is in your `load-path`.
 
 ### 2. Settings to use.
 
-Open your .emacs or init.el and if you extracted emmet-mode to a directory
-(if you installed from marmalade then this setting is needless)
+If you manually installed emmet-mode to `~/emacs.d/emmet-mode/`, add the following lines to your init.el or .emacs:
 
     (add-to-list 'load-path "~/emacs.d/emmet-mode")
-
-And then just require as normal:
-
     (require 'emmet-mode)
+
+If you installed from marmalade/MELPA then these you shouldn't need to do this.
 
 Enable it by running `M-x emmet-mode`.
 
@@ -43,7 +41,11 @@ You probably want to add it to auto-load on your sgml modes:
     (add-hook 'sgml-mode-hook 'emmet-mode) ;; Auto-start on any markup modes
     (add-hook 'css-mode-hook  'emmet-mode) ;; enable Emmet's css abbreviation.
 
-You can set default indent depth of HTML abbreviation:
+By default, inserted markup will be indented with indent-region, according to the buffer's mode.  To disable this, do:
+
+    (add-hook 'emmet-mode-hook (lambda () (setq emmet-indent-after-insert nil)))
+
+If you disable indent-region, you can set the default indent level thusly:
 
     (add-hook 'emmet-mode-hook (lambda () (setq emmet-indentation 2))) ;; indent 2 spaces.
 

--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -3067,12 +3067,13 @@ tbl))
             (sib2 (emmet-transform-ast (caddr ast) tag-maker)))
         (concat sib1 "\n" sib2))))))
 
+;; Indents text rigidly by inserting spaces
+;; Only matters if emmet-indent-after-insert is set to nil
 (defun emmet-indent (text)
   "Indent the text"
   (if text
-      (replace-regexp-in-string "\n" "\n    " (concat "\n" text))
+      (replace-regexp-in-string "\n" (concat "\n" (make-string emmet-indentation ?\ )) (concat "\n" text))
     nil))
-
 (defvar emmet-lorem-words
   '("lorem" "ipsum" "dolor" "sit" "amet," "consectetur" "adipiscing" "elit" "ut" "aliquam," "purus" "sit" "amet" "luctus" "venenatis,"
     "lectus" "magna" "fringilla" "urna," "porttitor" "rhoncus" "dolor" "purus" "non" "enim" "praesent" "elementum" "facilisis" "leo,"
@@ -3499,16 +3500,10 @@ tbl))
   :type '(number :tag "Spaces")
   :group 'emmet)
 
-(defun emmet-prettify (markup indent)
-  (destructuring-bind (first-col tab)
-      (if indent-tabs-mode
-          (list (apply #'concat (loop for i from 1 to (/ indent tab-width) collect "\t")) "\t")
-        (list (format (format "%%%ds" indent) "")
-              (format (format "%%%ds" emmet-indentation) "")))
-    (let ((internal-indent-1 "    "))
-      (concat first-col
-              (replace-regexp-in-string "\n" (concat "\n" first-col)
-                                        (replace-regexp-in-string internal-indent-1 tab markup))))))
+(defcustom emmet-indent-after-insert t
+  "Indent region after insert?"
+  :type 'boolean
+  :group 'emmet)
 
 (defvar emmet-use-css-transform nil
   "When true, transform Emmet snippets into CSS, instead of the usual HTML.")
@@ -3559,17 +3554,14 @@ For more information see `emmet-mode'."
         (if expr
             (let ((markup (emmet-transform (first expr))))
               (when markup
-                (let ((pretty (if (emmet-check-for-markup here)
-                                  markup
-                                (emmet-prettify markup (current-indentation)))))
-                  (when pretty
-                    (delete-region (second expr) (third expr))
-                    (emmet-insert-and-flash pretty)
-                    (when (and emmet-move-cursor-after-expanding (emmet-html-text-p markup))
-                      (let ((p (point)))
-                        (goto-char
-                         (+ (- p (length pretty))
-                            (emmet-html-next-insert-point pretty))))))))))))))
+                (delete-region (second expr) (third expr))
+                (emmet-insert-and-flash markup)
+                (let ((output-markup (buffer-substring-no-properties (second expr) (point))))
+                  (when (and emmet-move-cursor-after-expanding (emmet-html-text-p markup))
+                    (let ((p (point)))
+                      (goto-char
+                       (+ (- p (length output-markup))
+                        (emmet-html-next-insert-point output-markup)))))))))))))
 
 (defvar emmet-mode-keymap nil
   "Keymap for emmet minor mode.")
@@ -3680,11 +3672,12 @@ See also `emmet-expand-line'."
         (when markup
           (delete-region (line-beginning-position) (overlay-end ovli))
           (emmet-insert-and-flash markup)
-          (when (and emmet-move-cursor-after-expanding (emmet-html-text-p markup))
-            (let ((p (point)))
-              (goto-char
-               (+ (- p (length markup))
-                  (emmet-html-next-insert-point markup)))))))))
+          (let ((output-markup (buffer-substring-no-properties (line-beginning-position) (point))))
+            (when (and emmet-move-cursor-after-expanding (emmet-html-text-p markup))
+              (let ((p (point)))
+                (goto-char
+                 (+ (- p (length output-markup))
+                    (emmet-html-next-insert-point output-markup))))))))))
   (emmet-preview-abort))
 
 (defun emmet-html-next-insert-point (str)
@@ -3757,6 +3750,8 @@ cursor position will be moved to after the first quote."
   (emmet-remove-flash-ovl (current-buffer))
   (let ((here (point)))
     (insert markup)
+    (if emmet-indent-after-insert
+        (indent-region here (point)))
     (setq emmet-flash-ovl (make-overlay here (point)))
     (overlay-put emmet-flash-ovl 'face 'emmet-preview-output)
     (when (< 0 emmet-insert-flash-time)
@@ -3839,7 +3834,7 @@ accept it or skip it."
 		  (overlay-end emmet-preview-input))))
     (let ((output (emmet-transform string)))
       (when output
-        (emmet-prettify output indent)))))
+        output))))
 
 (defun emmet-update-preview (indent)
   (let* ((pretty (emmet-preview-transformed indent))

--- a/src/html-abbrev.el
+++ b/src/html-abbrev.el
@@ -685,9 +685,10 @@
             (sib2 (emmet-transform-ast (caddr ast) tag-maker)))
         (concat sib1 "\n" sib2))))))
 
+;; Indents text rigidly by inserting spaces
+;; Only matters if emmet-indent-after-insert is set to nil
 (defun emmet-indent (text)
   "Indent the text"
   (if text
-      (replace-regexp-in-string "\n" "\n    " (concat "\n" text))
+      (replace-regexp-in-string "\n" (concat "\n" (make-string emmet-indentation ?\ )) (concat "\n" text))
     nil))
-

--- a/src/test.el
+++ b/src/test.el
@@ -575,34 +575,14 @@
      (concat "    [PASS] | \"" name "\" 5 tests.\n"))))
 
 
-(defun emmet-prettify-test (lis)
-  (emmet-prettify (car lis) (cadr lis)))
-
 ;; indent
-(setq-default indent-tabs-mode nil)
-(emmet-run-test-case "Indent-1"
-  #'emmet-prettify-test
-  '((("<html>" 0) . "<html>")
-    (("<html>" 1) . " <html>")
-    (("<html>" 4) . "    <html>")
-    (("<html>" 8) . "        <html>")
-    (("<html>\n    <body></body>\n</html>" 1) . " <html>\n     <body></body>\n </html>")))
-(setq-default emmet-indentation 8)
-(emmet-run-test-case "Indent-2"
-  #'emmet-prettify-test
-  '((("<html>\n    <body></body>\n</html>" 0) . "<html>\n        <body></body>\n</html>")
-    (("<html>\n    <body></body>\n</html>" 4) . "    <html>\n            <body></body>\n    </html>")))
-(setq-default indent-tabs-mode t)
-(setq-default tab-width 2)
-(emmet-run-test-case "Indent-3"
-  #'emmet-prettify-test
-  '((("<html>\n    <body></body>\n</html>" 0) . "<html>\n\t<body></body>\n</html>")
-    (("<html>\n    <body></body>\n</html>" 4) . "\t\t<html>\n\t\t\t<body></body>\n\t\t</html>")))
-(setq-default tab-width 1)
-(emmet-run-test-case "Indent-4"
-  #'emmet-prettify-test
-  '((("<html>\n    <body></body>\n</html>" 0) . "<html>\n\t<body></body>\n</html>")
-    (("<html>\n    <body></body>\n</html>" 4) . "\t\t\t\t<html>\n\t\t\t\t\t<body></body>\n\t\t\t\t</html>")))
+;; NOTE: Indent now uses indent-region by default,
+;;   and inserts spaces based on emmet-indentation
+;;   if emmet-indent-after-insert is nil
+;; This needs tests, but they aren't written yet. :-(
+
+;; Old tests for previous indent behavior last seen:
+;;   commit: f56174e5905a40583b47f9737abee3af8da3faeb
 
 ;; start
 (emmet-test-cases)


### PR DESCRIPTION
So, this seems pretty solid - it doesn't break the existing tests, except for the indentation-specific ones, which I've removed.

I added a customizable variable, `emmet-indent-after-insert`, which turns this behavior on and off, and defaulted it to on.

The `emmet-indentation` variable now sets the number of spaces inserted in `emmet-transform`.  I figured it was safe to rely on its existence, since it's set up in a customized var in mode-def.
