### PR TITLE
Fix for first half of problem - self-closing tags now don't count

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -3735,10 +3735,12 @@ See also `emmet-expand-line'."
                           (= last-c ?<))
                      (return rti)))
             (t
-             (if (memq c '(?\t ?\n ?\r ?\s))
-                 (progn (setq c last-c))
-               (if (and (not intag) (not instring))
-                   (return rti))))))
+             (if (string-match "[^<]" (string c))
+                 (setq rti (1+ i))
+               (if (memq c '(?\t ?\n ?\r ?\s))
+                   (progn (setq c last-c))
+                 (if (and (not intag) (not instring))
+                     (return rti)))))))
     (length str))))
 
 (defvar emmet-flash-ovl nil)

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -246,10 +246,12 @@ See also `emmet-expand-line'."
                           (= last-c ?<))
                      (return rti)))
             (t
-             (if (memq c '(?\t ?\n ?\r ?\s))
-                 (progn (setq c last-c))
-               (if (and (not intag) (not instring))
-                   (return rti))))))
+             (if (string-match "[^<]" (string c))
+                 (setq rti (1+ i))
+               (if (memq c '(?\t ?\n ?\r ?\s))
+                   (progn (setq c last-c))
+                 (if (and (not intag) (not instring))
+                     (return rti)))))))
     (length str))))
 
 (defvar emmet-flash-ovl nil)


### PR DESCRIPTION
Partial fix for #35.  Alteration to `emmet-html-next-insert-point`, rather than suggested deduplication and use of `emmet-go-to-edit-point`.

Intended for discussion, not for merge in current form.
