### PR TITLE
Adapted emmet-html-next-insert-point to use emmet-go-to-edit-point

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -3714,8 +3714,8 @@ See also `emmet-expand-line'."
     (goto-char (point-min))
     (or
      (emmet-aif (emmet-go-to-edit-point 1 t) (- it 1)) ; try to find an edit point
-     (emmet-aif (re-search-forward ".+</") (- it 3))   ; try to place cursor after tag contents
-     (- (length str) 1))))                             ; ok, just go to the end
+     (emmet-aif (re-search-forward ".+</" nil t) (- it 3))   ; try to place cursor after tag contents
+     (length str))))                             ; ok, just go to the end
 
 (defvar emmet-flash-ovl nil)
 (make-variable-buffer-local 'emmet-flash-ovl)

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -225,8 +225,8 @@ See also `emmet-expand-line'."
     (goto-char (point-min))
     (or
      (emmet-aif (emmet-go-to-edit-point 1 t) (- it 1)) ; try to find an edit point
-     (emmet-aif (re-search-forward ".+</") (- it 3))   ; try to place cursor after tag contents
-     (- (length str) 1))))                             ; ok, just go to the end
+     (emmet-aif (re-search-forward ".+</" nil t) (- it 3))   ; try to place cursor after tag contents
+     (length str))))                             ; ok, just go to the end
 
 (defvar emmet-flash-ovl nil)
 (make-variable-buffer-local 'emmet-flash-ovl)


### PR DESCRIPTION
Issue https://github.com/smihica/emmet-mode/issues/35
Rewrote `emmet-html-next-insert-point` completely, now it reuses `emmet-go-to-edit-point` and looks much simpler.
Also, removed some bugs and unnecessary bindings from `emmet-go-to-edit-point` itself.
I didn't take care about not putting cursor after closing tag, though. But, surprisingly, I couldn't reproduce the behavior @pobocks mentioned in issue, because for me that

```
div/+div
```

expands into that

``` html
</div>
<div>|</div>
```

e. g. it adds a newline after closing tag, automatically makes that place an invalid edit point.
