### PR TITLE
Partial fix for issue #38: Fixed CSS expansion behavior

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -3720,6 +3720,7 @@ See also `emmet-expand-line'."
 
 (defun emmet-css-next-insert-point (str)
   (let ((regexp (if emmet-use-sass-syntax ": *\\($\\)" ": *\\(;\\)$")))
+    (set-match-data nil t)
     (string-match regexp str)
     (or (match-beginning 1) (length str))))
 

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -231,6 +231,7 @@ See also `emmet-expand-line'."
 
 (defun emmet-css-next-insert-point (str)
   (let ((regexp (if emmet-use-sass-syntax ": *\\($\\)" ": *\\(;\\)$")))
+    (set-match-data nil t)
     (string-match regexp str)
     (or (match-beginning 1) (length str))))
 


### PR DESCRIPTION
Made expanding of css snippets without values expanding properly. However, I did nothing about cursor positioning in Hiccup tags; actually, there's no any code handling this in the plugin, and it's development should be discussed.
