### PR TITLE
Fix error when accepting the expansion.

### DIFF
--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -223,7 +223,8 @@ See also `emmet-expand-line'."
 
 (defun emmet-preview-accept ()
   (interactive)
-  (let ((ovli emmet-preview-input))
+  (let ((ovli emmet-preview-input)
+        (expr (emmet-expr-on-line)))
     (if (not (and (overlayp ovli)
                   (bufferp (overlay-buffer ovli))))
         (message "Preview is not active")


### PR DESCRIPTION
When pressing enter to accept an expansion Emacs beeps with an error; enter for the second time accepts it.  This commit fixes that error, and accept it at the first enter key.
