### PR TITLE
Refs #61 - Escape using backslash inside { text }

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ you'll transform your snippet into the appropriate tag structure.
                              </p>
                              <span>here</span>
                               to continue
+    p{\{Escape brackets!\} and \\}
+                             <p>{Escape brackets} and \</p>
 
 #### Lorem-Ipsum generator
 

--- a/src/html-abbrev.el
+++ b/src/html-abbrev.el
@@ -287,9 +287,12 @@
 
 (defun emmet-text (input)
   "A zen coding expression innertext."
-  (emmet-parse "{\\(.*?\\)}" 2 "inner text"
-                   (let ((txt (emmet-split-numbering-expressions (elt it 1))))
-                     `((text ,txt) . ,input))))
+  (emmet-parse "{\\(\\(?:\\\\.\\|[^\\\\}]\\)*?\\)}" 2 "inner text"
+               (let ((txt (emmet-split-numbering-expressions (elt it 1))))
+                 (if (listp txt)
+                     (setq txt (cons (car txt) (cons (replace-regexp-in-string "\\\\\\(.\\)" "\\1" (cadr txt)) (cddr txt))))
+                   (setq txt (replace-regexp-in-string "\\\\\\(.\\)" "\\1" txt)))
+                 `((text ,txt) . ,input))))
 
 (defun emmet-properties (input)
   "A bracketed emmet property expression."
@@ -568,7 +571,7 @@
              (if self-closing? "/>"
                (concat ">"
                        (if tag-txt
-                           (if block-indentation? 
+                           (if block-indentation?
                                (emmet-indent tag-txt)
                              tag-txt))
                        (if content

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -19,12 +19,14 @@
   "Find the left bound of an emmet expr"
   (save-excursion (save-match-data
     (let ((char (char-before))
-          (in-style-attr (looking-back "style=[\"'][^\"']*")))
+          (in-style-attr (looking-back "style=[\"'][^\"']*"))
+          (syn-tab (make-syntax-table)))
+      (modify-syntax-entry ?\\ "\\")
       (while char
         (cond ((and in-style-attr (member char '(?\" ?\')))
                (setq char nil))
               ((member char '(?\} ?\] ?\)))
-               (with-syntax-table (standard-syntax-table)
+               (with-syntax-table syn-tab
                  (backward-sexp) (setq char (char-before))))
               ((eq char ?\>)
                (if (looking-back "<[^>]+>" (line-beginning-position))

--- a/src/test.el
+++ b/src/test.el
@@ -670,6 +670,8 @@
   #'emmet-regression-54-test
   '((("span.whut[thing=\"stuff\"]{Huh?}") . "<div class=\"broken\"><span class=\"whut\" thing=\"stuff\">Huh?</span>")))
 
+(define-emmet-transform-html-test-case regression-61-bracket-escapes
+  "div{\\}\\}\\}}" ("<div>}}}</div>"))
 
 ;; start
 (emmet-test-cases)


### PR DESCRIPTION
This fixes half the problem specified in #61.  The doc change
is technically inaccurate - opening brackets don't actually NEED to
be escaped - p{{\}} works as well as p{\{\}}.  But they CAN be escaped,
so I used the most regular version.

The part that is NOT fixed is that a | character, escaped or not, will
prevent the expression from being parsed AT ALL.