### PR TITLE
Added multi-line * wrap functionality as per #81

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -632,11 +632,12 @@ accept it or skip it."
          (to-wrap (if multi
                       (split-string txt "\n")
                     (list txt)))
-         (initial-elements (replace-regexp-in-string "\\(.*>\\)?[^>*]+\\*?$" "\\1" wrap-with t))
-         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\*?$" "\\2" wrap-with t))
+         (initial-elements (replace-regexp-in-string "\\(.*\\(\\+\\|>\\)\\)?[^>*]+\\*?[[:digit:]]*$" "\\1" wrap-with t))
+         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\(\\*[[:digit:]]+$\\)?\\*?$" "\\2" wrap-with t))
+         (multiplier-expr (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\(\\*[[:digit:]]+$\\)?\\*?$" "\\3" wrap-with t))
          (expr (concat
                 initial-elements
-                (mapconcat (lambda (el) (concat terminal-element "{!!!" (secure-hash 'sha1 el) "!!!}"))
+                (mapconcat (lambda (el) (concat terminal-element "{!!!" (secure-hash 'sha1 el) "!!!}" multiplier-expr))
                            to-wrap
                            "+")))
          (markup

--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -632,24 +632,31 @@ accept it or skip it."
          (to-wrap (if multi
                       (split-string txt "\n")
                     (list txt)))
-         (initial-elements (replace-regexp-in-string "\\(.*>\\)?[^>*]+\\*?$" "\\1" wrap-with))
-         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\*?$" "\\2" wrap-with))
+         (initial-elements (replace-regexp-in-string "\\(.*>\\)?[^>*]+\\*?$" "\\1" wrap-with t))
+         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\*?$" "\\2" wrap-with t))
          (expr (concat
                 initial-elements
-                (mapconcat (lambda (el) (concat terminal-element "{" el "}")) to-wrap "+")))
-
-         (markup (emmet-transform expr))
-         (debug-shit (message "initial-elements: %s\nterminal-element: %s\n expr: %s\n markup: %s" initial-elements terminal-element expr markup))
-         )
-         (when markup
-           (delete-region (region-beginning) (region-end))
-           (insert markup)
-           (indent-region (region-beginning) (region-end))
-           (let ((end (region-end)))
-             (goto-char (region-beginning))
-             (unless (ignore-errors (progn (emmet-next-edit-point 1) t))
-               (goto-char end)))
-           )))
+                (mapconcat (lambda (el) (concat terminal-element "{!!!" (secure-hash 'sha1 el) "!!!}"))
+                           to-wrap
+                           "+")))
+         (markup
+          (reduce
+           (lambda (result text)
+             (replace-regexp-in-string
+              (concat "!!!" (secure-hash 'sha1 text) "!!!")
+              text
+              result t t))
+           to-wrap
+           :initial-value (emmet-transform expr))))
+    (when markup
+      (delete-region (region-beginning) (region-end))
+      (insert markup)
+      (indent-region (region-beginning) (region-end))
+      (let ((end (region-end)))
+        (goto-char (region-beginning))
+        (unless (ignore-errors (progn (emmet-next-edit-point 1) t))
+          (goto-char end)))
+      )))
 
 ;;;###autoload
 (defun emmet-next-edit-point (count)

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -479,24 +479,31 @@ accept it or skip it."
          (to-wrap (if multi
                       (split-string txt "\n")
                     (list txt)))
-         (initial-elements (replace-regexp-in-string "\\(.*>\\)?[^>*]+\\*?$" "\\1" wrap-with))
-         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\*?$" "\\2" wrap-with))
+         (initial-elements (replace-regexp-in-string "\\(.*>\\)?[^>*]+\\*?$" "\\1" wrap-with t))
+         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\*?$" "\\2" wrap-with t))
          (expr (concat
                 initial-elements
-                (mapconcat (lambda (el) (concat terminal-element "{" el "}")) to-wrap "+")))
-
-         (markup (emmet-transform expr))
-         (debug-shit (message "initial-elements: %s\nterminal-element: %s\n expr: %s\n markup: %s" initial-elements terminal-element expr markup))
-         )
-         (when markup
-           (delete-region (region-beginning) (region-end))
-           (insert markup)
-           (indent-region (region-beginning) (region-end))
-           (let ((end (region-end)))
-             (goto-char (region-beginning))
-             (unless (ignore-errors (progn (emmet-next-edit-point 1) t))
-               (goto-char end)))
-           )))
+                (mapconcat (lambda (el) (concat terminal-element "{!!!" (secure-hash 'sha1 el) "!!!}"))
+                           to-wrap
+                           "+")))
+         (markup
+          (reduce
+           (lambda (result text)
+             (replace-regexp-in-string
+              (concat "!!!" (secure-hash 'sha1 text) "!!!")
+              text
+              result t t))
+           to-wrap
+           :initial-value (emmet-transform expr))))
+    (when markup
+      (delete-region (region-beginning) (region-end))
+      (insert markup)
+      (indent-region (region-beginning) (region-end))
+      (let ((end (region-end)))
+        (goto-char (region-beginning))
+        (unless (ignore-errors (progn (emmet-next-edit-point 1) t))
+          (goto-char end)))
+      )))
 
 ;;;###autoload
 (defun emmet-next-edit-point (count)

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -19,7 +19,7 @@
   "Find the left bound of an emmet expr"
   (save-excursion (save-match-data
     (let ((char (char-before))
-          (in-style-attr (looking-back "style=[\"'][^\"']*"))
+          (in-style-attr (looking-back "style=[\"'][^\"']*" nil))
           (syn-tab (make-syntax-table)))
       (modify-syntax-entry ?\\ "\\")
       (while char
@@ -474,12 +474,20 @@ accept it or skip it."
 (defun emmet-wrap-with-markup (wrap-with)
   "Wrap region with markup."
   (interactive "sExpression to wrap with: ")
-  (let* ((to-wrap (buffer-substring-no-properties (region-beginning) (region-end)))
-         (expr (concat wrap-with ">{!EMMET-TO-WRAP-REPLACEMENT!}"))
-         (markup (replace-regexp-in-string
-                  "!EMMET-TO-WRAP-REPLACEMENT!" to-wrap
-                  (emmet-transform expr)
-                  t t)))
+  (let* ((multi (string-match "\\*$" wrap-with))
+         (txt (buffer-substring-no-properties (region-beginning) (region-end)))
+         (to-wrap (if multi
+                      (split-string txt "\n")
+                    (list txt)))
+         (initial-elements (replace-regexp-in-string "\\(.*>\\)?[^>*]+\\*?$" "\\1" wrap-with))
+         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\*?$" "\\2" wrap-with))
+         (expr (concat
+                initial-elements
+                (mapconcat (lambda (el) (concat terminal-element "{" el "}")) to-wrap "+")))
+
+         (markup (emmet-transform expr))
+         (debug-shit (message "initial-elements: %s\nterminal-element: %s\n expr: %s\n markup: %s" initial-elements terminal-element expr markup))
+         )
          (when markup
            (delete-region (region-beginning) (region-end))
            (insert markup)
@@ -503,4 +511,3 @@ accept it or skip it."
     (error "First edit point reached.")))
 
 (provide 'emmet-mode)
-

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -479,11 +479,12 @@ accept it or skip it."
          (to-wrap (if multi
                       (split-string txt "\n")
                     (list txt)))
-         (initial-elements (replace-regexp-in-string "\\(.*>\\)?[^>*]+\\*?$" "\\1" wrap-with t))
-         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\*?$" "\\2" wrap-with t))
+         (initial-elements (replace-regexp-in-string "\\(.*\\(\\+\\|>\\)\\)?[^>*]+\\*?[[:digit:]]*$" "\\1" wrap-with t))
+         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\(\\*[[:digit:]]+$\\)?\\*?$" "\\2" wrap-with t))
+         (multiplier-expr (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\(\\*[[:digit:]]+$\\)?\\*?$" "\\3" wrap-with t))
          (expr (concat
                 initial-elements
-                (mapconcat (lambda (el) (concat terminal-element "{!!!" (secure-hash 'sha1 el) "!!!}"))
+                (mapconcat (lambda (el) (concat terminal-element "{!!!" (secure-hash 'sha1 el) "!!!}" multiplier-expr))
                            to-wrap
                            "+")))
          (markup

--- a/src/test.el
+++ b/src/test.el
@@ -655,6 +655,11 @@
   #'emmet-wrap-with-markup-test
   '((("div>ul>li" "I am some\nmultiline\n  text") . "<div>\n  <ul>\n    <li>I am some\n      multiline\n      text</li>\n  </ul>\n</div>")))
 
+(emmet-run-test-case "Wrap with per-line markup (trailing *)"
+                     #'emmet-wrap-with-markup-test
+                     '((("div>ul>li*" "I am some\nmultiline\n  text") .
+                        "<div>\n  <ul>\n    <li>I am some</li>\n    <li>multiline</li>\n    <li>  text</li>\n  </ul>\n</div>")))
+
 ;; Regression test for #54 (broken emmet-find-left-bound behavior
 ;;   after tag with attributes)
 (defun emmet-regression-54-test (lis)


### PR DESCRIPTION
This is a proof-of-concept - DO NOT MERGE YET! it needs to do the token-replacement jazz the original
version did, because right now this will fail if the content of the
txt/lines includes unmatched braces in various configurations.

I think the overall plan is sound: split expression into leading and
terminal components, render the text as a list (either a one-element
list of all text or a multiline list, depending on trailing *), and
create a terminal phrase consisting of "terminal-element{TOKEN}" joined
on "+"

To do: render list into a-list of '((hash-of-txt . txt), ...), mapconcat
the hash replacement instead of the text, then run replace over result.
Write tests.  Also, tests appear to be broken on master, at least on my machine.