### PR TITLE
Two minor fixes for emmet-wrap-with-markup

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -305,13 +305,12 @@ For more information see `emmet-mode'."
                 (emmet-reposition-cursor expr))))))))
 
 (defvar emmet-mode-keymap
-  (let
-      ((map (make-sparse-keymap)))
+  (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-j") 'emmet-expand-line)
     (define-key map (kbd "<C-return>") 'emmet-expand-line)
     (define-key map (kbd "<C-M-right>") 'emmet-next-edit-point)
     (define-key map (kbd "<C-M-left>") 'emmet-prev-edit-point)
-    (define-key map (kbd "C-c w") 'emmet-wrap-with-markup)
+    (define-key map (kbd "C-c C-c w") 'emmet-wrap-with-markup)
     map)
   "Keymap for emmet minor mode.")
 
@@ -4011,7 +4010,7 @@ tbl))
   (emmet-join-string
    (mapcar
     #'(lambda (expr)
-        (let* 
+        (let*
 	    ((hash-map (if emmet-use-sass-syntax emmet-sass-snippets emmet-css-snippets))
 	     (basement
 	      (emmet-aif

--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -655,16 +655,31 @@ See `emmet-preview-online'."
   "Wrap region with markup."
   (interactive "sExpression to wrap with: ")
   (let* ((multi (string-match "\\*$" wrap-with))
-         (txt (buffer-substring-no-properties (region-beginning) (region-end)))
+         (txt (buffer-substring-no-properties
+               (region-beginning) (region-end)))
          (to-wrap (if multi
                       (split-string txt "\n")
                     (list txt)))
-         (initial-elements (replace-regexp-in-string "\\(.*\\(\\+\\|>\\)\\)?[^>*]+\\*?[[:digit:]]*$" "\\1" wrap-with t))
-         (terminal-element (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\(\\*[[:digit:]]+$\\)?\\*?$" "\\2" wrap-with t))
-         (multiplier-expr (replace-regexp-in-string "\\(.*>\\)?\\([^>*]+\\)\\(\\*[[:digit:]]+$\\)?\\*?$" "\\3" wrap-with t))
+         (initial-elements
+           (replace-regexp-in-string
+            "\\(.*\\(\\+\\|>\\)\\)?[^>*]+\\*?[[:digit:]]*$"
+            "\\1" wrap-with t))
+         (terminal-element
+           (replace-regexp-in-string
+            "\\(.*>\\)?\\([^>*]+\\)\\(\\*[[:digit:]]+$\\)?\\*?$"
+            "\\2" wrap-with t))
+         (multiplier-expr
+           (replace-regexp-in-string
+            "\\(.*>\\)?\\([^>*]+\\)\\(\\*[[:digit:]]+$\\)?\\*?$"
+            "\\3" wrap-with t))
          (expr (concat
                 initial-elements
-                (mapconcat (lambda (el) (concat terminal-element "{!!!" (secure-hash 'sha1 el) "!!!}" multiplier-expr))
+                (mapconcat (lambda (el)
+                             (concat terminal-element
+                                     "{!!!"
+                                     (secure-hash 'sha1 el)
+                                     "!!!}"
+                                     multiplier-expr))
                            to-wrap
                            "+")))
          (markup
@@ -679,12 +694,7 @@ See `emmet-preview-online'."
     (when markup
       (delete-region (region-beginning) (region-end))
       (insert markup)
-      (indent-region (region-beginning) (region-end))
-      (let ((end (region-end)))
-        (goto-char (region-beginning))
-        (unless (ignore-errors (progn (emmet-next-edit-point 1) t))
-          (goto-char end)))
-      )))
+      (indent-region (region-beginning) (region-end)))))
 
 ;;;###autoload
 (defun emmet-next-edit-point (count)


### PR DESCRIPTION
Hello. This PR consists of two changes:

1. Changed emmet-wrap-with-markup to leave point at the end of inserted markup, instead of trying to jump edit points. This makes emmet-wrap-with-markup usable in keyboard macros, and avoids bugs in emmet-next-edit-point (I have encountered at least one, still trying to debug it).

2. Single alphabetical letter key bindings under the ‘C-c’ prefix map are reserved for users (as per elisp manual 22.2.1 Major Mode Conventions). Moved the binding for emmet-wrap-with-markup under ‘C-c C-c w’