### PR TITLE
Support boolean attributes for HTML tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,12 +283,16 @@ you'll transform your snippet into the appropriate tag structure.
 #### Properties
 
     b[x]                     <b x=""></b>
+    b[x.]                    <b x></b>
     b[x=]                    <b x=""></b>
     b[x=""]                  <b x=""></b>
     b[x=y]                   <b x="y"></b>
     b[x="y"]                 <b x="y"></b>
     b[x="()"]                <b x="()"></b>
     b[x m]                   <b x="" m=""></b>
+    b[x. m]                  <b x m=""></b>
+    b[x m.]                  <b x="" m></b>
+    b[x. m.]                 <b x m></b>
     b[x= m=""]               <b x="" m=""></b>
     b[x=y m=l]               <b x="y" m="l"></b>
     b/[x=y m=l]              <b x="y" m="l"/>

--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -3313,9 +3313,12 @@ tbl))
    (emmet-run
     emmet-name
     (let ((name (cdr expr)))
-      (emmet-pif (emmet-prop-value name input)
-                     it
-                     `((,(read name) "") . ,input))))))
+      (emmet-pif (emmet-parse "\\.\\(.*?\\)" 2 "."
+                              `((,(read name)) . ,input))
+                 it
+                 (emmet-pif (emmet-prop-value name input)
+                            it
+                            `((,(read name) "") . ,input)))))))
 
 (defun emmet-prop-value (name input)
   (emmet-pif (emmet-parse "=\"\\(.*?\\)\"" 2
@@ -3623,9 +3626,12 @@ tbl))
                           (emmet-mapconcat-or-empty
                            " " merged-tag-props " " nil
                            (lambda (prop)
-                             (let ((key (car prop)))
-                               (concat (if (symbolp key) (symbol-name key) key)
-                                       "=\"" (cadr prop) "\""))))))
+                             (let* ((key (car prop))
+                                    (key (if (symbolp key) (symbol-name key) key))
+                                    (value (cadr prop)))
+                               (if value
+                                   (concat key "=\"" value "\"")
+                                 key))))))
           (content-multiline? (and content (string-match "\n" content)))
           (block-tag?         (and settings (gethash "block" settings)))
           (self-closing?      (and (not (or tag-txt content))

--- a/src/test.el
+++ b/src/test.el
@@ -278,12 +278,16 @@
 
 (define-emmet-transform-html-test-case Properties
   "a[x]"                    ("<a href=\"\" x=\"\"></a>")
+  "a[x.]"                   ("<a href=\"\" x></a>")
   "a[x=]"                   ("<a href=\"\" x=\"\"></a>")
   "a[x=\"\"]"               ("<a href=\"\" x=\"\"></a>")
   "a[x=y]"                  ("<a href=\"\" x=\"y\"></a>")
   "a[x=\"y\"]"              ("<a href=\"\" x=\"y\"></a>")
   "a[x=\"()\"]"             ("<a href=\"\" x=\"()\"></a>")
   "a[x m]"                  ("<a href=\"\" x=\"\" m=\"\"></a>")
+  "a[x. m]"                 ("<a href=\"\" x m=\"\"></a>")
+  "a[x m.]"                 ("<a href=\"\" x=\"\" m></a>")
+  "a[x. m.]"                ("<a href=\"\" x m></a>")
   "a[x= m=\"\"]"            ("<a href=\"\" x=\"\" m=\"\"></a>")
   "a[x=y m=l]"              ("<a href=\"\" x=\"y\" m=\"l\"></a>")
   "a/[x=y m=l]"             ("<a href=\"\" x=\"y\" m=\"l\"/>")


### PR DESCRIPTION
For example,
```
script[src defer.]
```
expands to
```
<script src="" defer></script>
```

TODO: Support boolean attributes for the other filters