### PR TITLE
Check jsx major mode before expanding class using className

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ If you want to use emmet with react-js's JSX, you probably want emmet to expand 
 
     (setq emmet-expand-jsx-className? t) ;; default nil
 
+This will set the class attribute to className on the following modes:
+
+- jsx-mode
+- rjsx-mode
+- js-jsx-mode
+- js2-jsx-mode
+- js-mode
+
+If you would like to configure which modes to use:
+
+    (setq emmet-expand-jsx-className-modes '(modes...))
+
+For example:
+
+    (setq emmet-expand-jsx-className-modes '(rjsx-mode web-mode))
+
 If you want to customize Self-closing tags style:
 
     (setq emmet-self-closing-tag-style " /") ;; default "/"

--- a/src/html-abbrev.el
+++ b/src/html-abbrev.el
@@ -427,6 +427,9 @@
 (defvar emmet-expand-jsx-className? nil
   "Wether to use `className' when expanding `.classes'")
 
+(defvar emmet-expand-jsx-className-modes '(rjsx-mode js-jsx-mode js2-jsx-mode jsx-mode js-mode)
+  "Which modes to check before using jsx class expansion")
+
 (emmet-defparameter
  emmet-tag-settings-table
  (gethash "tags" (gethash "html" emmet-preferences)))
@@ -537,6 +540,10 @@
                   contents))))))
       (eval (iter lines 'a nil nil)))))
 
+(defun emmet-jsx-supported-mode? ()
+  "Is the current mode we're on enabled for jsx class attribute expansion?"
+  (member major-mode emmet-expand-jsx-className-modes))
+
 (defun emmet-make-html-tag (tag-name tag-has-body? tag-id tag-classes tag-props tag-txt settings content)
   "Create HTML markup string"
   (emmet-aif
@@ -550,7 +557,7 @@
        (puthash tag-name fn emmet-tag-snippets-table)))
 
    (let* ((id           (emmet-concat-or-empty " id=\"" tag-id "\""))
-          (class-attr  (if emmet-expand-jsx-className? " className=\"" " class=\""))
+          (class-attr  (if (and emmet-expand-jsx-className? (emmet-jsx-supported-mode?)) " className=\"" " class=\""))
           (classes      (emmet-mapconcat-or-empty class-attr tag-classes " " "\""))
           (props        (let* ((tag-props-default
                                 (and settings (gethash "defaultAttr" settings)))


### PR DESCRIPTION
Not sure if you're interested in these features but I saw if you put jsx support on for className="" vs class="" it just always className. When using normal HTML, php, etc files I didn't want className but class so it got a little cumbersome.

I added a quick check and introduced emmet-expand-jsx-className-modes which is a list of modes to use jsx tags with. I set the default to 

`'(rjsx-mode js-jsx-mode js2-jsx-mode jsx-mode js-mode)`

and the user can configure that var (see README)

I wasn't able to get tests working, if you can help me out with that I will update the test script. My version of emacs doesn't support --script so `make test` just fails.