### PR TITLE
Replace depricated cl function usages with cl-lib equivs

### DIFF
--- a/src/html-abbrev.el
+++ b/src/html-abbrev.el
@@ -1,6 +1,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; XML abbrev
 
+(require 'cl-lib)
+
 (emmet-defparameter
  emmet-tag-aliases-table
  (gethash "aliases" (gethash "html" emmet-snippets)))
@@ -213,7 +215,7 @@
                                 (fifth tag-data))
                         :test #'(lambda (p1 p2)
                                   (eql (car p1) (car p2)))))
-                 (setf (sixth first-tag-data) (sixth tag-data))
+                 (setf (cl-sixth first-tag-data) (cl-sixth tag-data))
                  (setf (cdr rt) (concat (cdr rt) input))
                  rt))
            (puthash tag-name expr emmet-tag-aliases-table)))

--- a/src/test.el
+++ b/src/test.el
@@ -5,8 +5,10 @@
 
 (emmet-defparameter *emmet-test-cases* nil)
 
+(require 'cl-lib)
+
 (defun emmet-run-test-case (name fn cases)
-  (let ((res (loop for c in cases
+  (let ((res (cl-loop for c in cases
                     for i to (1- (length cases)) do
                     (let ((expected (cdr c))
                           (actual (funcall fn (car c))))
@@ -15,7 +17,7 @@
                          (concat "*** [FAIL] | \"" name "\" " (number-to-string i) "\n\n"
                                  (format "%s" (car c)) "\t=>\n\n"
                                  "Expected\n" (format "%s" expected) "\n\nActual\n" (format "%s" actual) "\n\n"))
-                        (return 'fail))))))
+                        (cl-return 'fail))))))
     (if (not (eql res 'fail))
         (princ (concat "    [PASS] | \"" name "\" "
                        (number-to-string (length cases)) " tests.\n")))))
@@ -32,7 +34,7 @@
                  (setq *emmet-test-cases*
                        (cons (cons name (cons fn defs)) *emmet-test-cases*))))))
           (t
-           (loop for test in (reverse *emmet-test-cases*) do
+           (cl-loop for test in (reverse *emmet-test-cases*) do
                  (let ((name  (symbol-name (car test)))
                        (fn    (cadr test))
                        (cases (cddr test)))
@@ -41,7 +43,7 @@
 (defmacro define-emmet-transform-test-case (name fn &rest tests)
   `(emmet-test-cases 'assign ',name
                          ,fn
-                         ',(loop for x on tests by #'cddr collect
+                         ',(cl-loop for x on tests by #'cddr collect
                                  (cons (car x)
                                        (emmet-join-string (cadr x)
                                                               "\n")))))
@@ -54,7 +56,7 @@
 (defmacro define-emmet-unit-test-case (name fn &rest tests)
   `(emmet-test-cases 'assign ',name
                          ,fn
-                         ',(loop for x on tests by #'cddr collect
+                         ',(cl-loop for x on tests by #'cddr collect
                                  (cons (car x) (cadr x)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
👋 Hello and thanks for emmet-mode!

I noticed that this package is using the deprecated cl library and so it was giving me errors on emacs27+ and it seemed easy enough to update the usages of old functions from cl to the new ones in the namespaced cl-lib. 

One caveat with this PR is that it effectively drops support for emacs < 24 (when cl-lib began shipping by default). The test suite is passing as much as it does currently on master and I did a bit of regression testing in my emacs (though I am not a power user, just some small things).

Figured I would PR the changes to prove it works and if you're interested you can guide me on what needs to be updated in order to release this 👍 