### PR TITLE
Add option to interpret any classes beyond the first as object property lookups

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -3489,6 +3489,9 @@ tbl))
 (defvar emmet-expand-jsx-className? nil
   "Wether to use `className' when expanding `.classes'")
 
+(defvar emmet-jsx-className-braces? nil
+  "Wether to wrap classNames in {} instead of \"\"")
+
 (emmet-defparameter
  emmet-tag-settings-table
  (gethash "tags" (gethash "html" emmet-preferences)))
@@ -3612,8 +3615,12 @@ tbl))
        (puthash tag-name fn emmet-tag-snippets-table)))
 
    (let* ((id           (emmet-concat-or-empty " id=\"" tag-id "\""))
-          (class-attr  (if emmet-expand-jsx-className? " className=\"" " class=\""))
-          (classes      (emmet-mapconcat-or-empty class-attr tag-classes " " "\""))
+         (class-attr  (if emmet-expand-jsx-className?
+			   (if emmet-jsx-className-braces? " className={" " className=\"")
+			 " class=\""))
+	  (class-list-closer (if emmet-jsx-className-braces? "}" "\""))
+	  (class-list-delimiter (if emmet-jsx-className-braces? "." " "))
+          (classes      (emmet-mapconcat-or-empty class-attr tag-classes class-list-delimiter class-list-closer))
           (props        (let* ((tag-props-default
                                 (and settings (gethash "defaultAttr" settings)))
                                (merged-tag-props

--- a/src/html-abbrev.el
+++ b/src/html-abbrev.el
@@ -427,6 +427,9 @@
 (defvar emmet-expand-jsx-className? nil
   "Wether to use `className' when expanding `.classes'")
 
+(defvar emmet-jsx-className-braces? nil
+  "Wether to wrap classNames in {} instead of \"\"")
+
 (emmet-defparameter
  emmet-tag-settings-table
  (gethash "tags" (gethash "html" emmet-preferences)))
@@ -550,8 +553,12 @@
        (puthash tag-name fn emmet-tag-snippets-table)))
 
    (let* ((id           (emmet-concat-or-empty " id=\"" tag-id "\""))
-          (class-attr  (if emmet-expand-jsx-className? " className=\"" " class=\""))
-          (classes      (emmet-mapconcat-or-empty class-attr tag-classes " " "\""))
+         (class-attr  (if emmet-expand-jsx-className?
+			   (if emmet-jsx-className-braces? " className={" " className=\"")
+			 " class=\""))
+	  (class-list-closer (if emmet-jsx-className-braces? "}" "\""))
+	  (class-list-delimiter (if emmet-jsx-className-braces? "." " "))
+          (classes      (emmet-mapconcat-or-empty class-attr tag-classes class-list-delimiter class-list-closer))
           (props        (let* ((tag-props-default
                                 (and settings (gethash "defaultAttr" settings)))
                                (merged-tag-props

--- a/src/test.el
+++ b/src/test.el
@@ -1,7 +1,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Test-cases
 
-(load-file (concat (file-name-directory load-file-name) "../emmet-mode.el"))
+(load-file (concat (file-name-directory (or load-file-name (buffer-file-name))) "../emmet-mode.el"))
 
 (emmet-defparameter *emmet-test-cases* nil)
 
@@ -706,6 +706,29 @@
   #'emmet-expand-jsx-className?-test
   '(((".jsx>ul.lis>li.itm{x}*2") . "<div className=\"jsx\">\n  <ul className=\"lis\">\n    <li className=\"itm\">x</li>\n    <li className=\"itm\">x</li>\n  </ul>\n</div>")))
 
+(defun emmet-expand-jsx-classNameBraces?-test (lis)
+  (let ((es (car lis))
+        (indent-tabs-mode nil)
+        (tab-width 2)
+        (standard-indent 2)
+        (emmet-expand-jsx-className? t)
+	(emmet-jsx-className-braces? t))
+    (with-temp-buffer
+      (emmet-mode 1)
+      (sgml-mode)
+      (insert es)
+      (emmet-expand-line nil)
+      (buffer-string))))
+
+(emmet-run-test-case "JSX's classNameBraces 1"
+  #'emmet-expand-jsx-classNameBraces?-test
+  '(((".jsx\.foo") . "<div className={jsx.foo}></div>")))
+
+(emmet-run-test-case "JSX's classNameBraces 2"
+  #'emmet-expand-jsx-classNameBraces?-test
+  '(((".jsx>ul.lis>li.itm.bar{x}*2") . "<div className={jsx}>\n  <ul className={lis}>\n    <li className={itm.bar}>x</li>\n    <li className={itm.bar}>x</li>\n  </ul>\n</div>")))
+
+
 (defun emmet-self-closing-tag-style-test (lis)
   (let ((es (car lis))
         (emmet-preview-default nil))
@@ -737,3 +760,4 @@
 
 ;; start
 (emmet-test-cases)
+


### PR DESCRIPTION
Add `emmet-jsx-className-braces?` variable to use braces (`{ }`) so that React object style classNames are easier to use.

e.g.

`div.obj.prop` -> `<div className={obj.prop}></div>` 