### PR TITLE
feat: add support for more style tags

### DIFF
--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -272,7 +272,7 @@ e. g. without semicolons")
   (let* ((style-attr-end "[^=][\"']")
          (style-attr-begin "style=[\"']")
          (style-tag-end "</style>")
-         (style-tag-begin "<style>"))
+         (style-tag-begin "<style.*>"))
     (and emmet-use-style-tag-and-attr-detection
          (or
           (emmet-check-if-between style-attr-begin style-attr-end) ; style attr


### PR DESCRIPTION
when editing vue files, `<style lang="less" scoped></style>` can be detected to use `emmet-css-transform` but not `emmet-html-transform`.