### PR TITLE
feat: add support for single and double quotes in html - jsx/tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Or if you don't want to move cursor after expanding:
 
     (setq emmet-move-cursor-after-expanding nil) ;; default t
 
+If you want to customize Auto-quote html - jsx/tsx tag style:
+
+    (setq emmet-html-auto-quote-style 1) ;; default double quote
+
+    ;; only 1 - double quote and 2 - single quote are valid.
+    ;; eg. <a href=""></a>, <a href=''></a>
+
 If you want to customize Self-closing tags style:
 
     (setq emmet-self-closing-tag-style " /") ;; default "/"

--- a/emmet-mode.el
+++ b/emmet-mode.el
@@ -199,6 +199,12 @@ and leaving the point in place."
   :type '(number :tag "Spaces")
   :group 'emmet)
 
+(defcustom emmet-html-auto-quote-style 1
+  "Auto-quoting style."
+  :type '(choice (const :tag "Auto-quotes with double quote" 1)
+                 (const :tag "Auto-quotes with single quote" 2))
+  :group 'emmet)
+
 (defcustom emmet-indent-after-insert t
   "Indent region after insert?"
   :type 'boolean
@@ -3692,13 +3698,14 @@ Return `(,inner-text ,input-without-inner-text) if succeeds, otherwise return
          (funcall fn content)
        (puthash tag-name fn emmet-tag-snippets-table)))
 
-   (let* ((id           (emmet-concat-or-empty " id=\"" tag-id "\""))
+   (let* ((html-auto-quote-style (if (eq emmet-html-auto-quote-style 1) "\"" "'"))
+          (id           (emmet-concat-or-empty (concat " id=" html-auto-quote-style) tag-id html-auto-quote-style))
           (class-attr   (if (emmet-jsx-supported-mode?)
                             (if emmet-jsx-className-braces?
                                 " className={"
-                              " className=\"")
-                          " class=\""))
-	  (class-list-closer (if emmet-jsx-className-braces? "}" "\""))
+                              (concat " className=" html-auto-quote-style))
+                          (concat " class=" html-auto-quote-style)))
+	  (class-list-closer (if emmet-jsx-className-braces? "}" html-auto-quote-style))
 	  (class-list-delimiter (if emmet-jsx-className-braces? "." " "))
           (classes      (emmet-mapconcat-or-empty class-attr tag-classes class-list-delimiter class-list-closer))
           (props        (let* ((tag-props-default
@@ -3725,7 +3732,7 @@ Return `(,inner-text ,input-without-inner-text) if succeeds, otherwise return
                                      (if (and (emmet-jsx-supported-mode?)
                                               (emmet-jsx-prop-value-var? val))
                                          "%s=%s"
-                                       "%s=\"%s\"")))
+                                       (concat "%s=" html-auto-quote-style "%s" html-auto-quote-style))))
                                (if val (format format-string key val) key))))))
           (content-multiline? (and content (string-match "\n" content)))
           (block-tag?         (and settings (gethash "block" settings)))

--- a/src/html-abbrev.el
+++ b/src/html-abbrev.el
@@ -622,13 +622,14 @@ Return `(,inner-text ,input-without-inner-text) if succeeds, otherwise return
          (funcall fn content)
        (puthash tag-name fn emmet-tag-snippets-table)))
 
-   (let* ((id           (emmet-concat-or-empty " id=\"" tag-id "\""))
+   (let* ((html-auto-quote-style (if (eq emmet-html-auto-quote-style 1) "\"" "'"))
+          (id           (emmet-concat-or-empty (concat " id=" html-auto-quote-style) tag-id html-auto-quote-style))
           (class-attr   (if (emmet-jsx-supported-mode?)
                             (if emmet-jsx-className-braces?
                                 " className={"
-                              " className=\"")
-                          " class=\""))
-	  (class-list-closer (if emmet-jsx-className-braces? "}" "\""))
+                              (concat " className=" html-auto-quote-style))
+                          (concat " class=" html-auto-quote-style)))
+	  (class-list-closer (if emmet-jsx-className-braces? "}" html-auto-quote-style))
 	  (class-list-delimiter (if emmet-jsx-className-braces? "." " "))
           (classes      (emmet-mapconcat-or-empty class-attr tag-classes class-list-delimiter class-list-closer))
           (props        (let* ((tag-props-default
@@ -655,7 +656,7 @@ Return `(,inner-text ,input-without-inner-text) if succeeds, otherwise return
                                      (if (and (emmet-jsx-supported-mode?)
                                               (emmet-jsx-prop-value-var? val))
                                          "%s=%s"
-                                       "%s=\"%s\"")))
+                                       (concat "%s=" html-auto-quote-style "%s" html-auto-quote-style))))
                                (if val (format format-string key val) key))))))
           (content-multiline? (and content (string-match "\n" content)))
           (block-tag?         (and settings (gethash "block" settings)))

--- a/src/mode-def.el
+++ b/src/mode-def.el
@@ -43,6 +43,12 @@
   :type '(number :tag "Spaces")
   :group 'emmet)
 
+(defcustom emmet-html-auto-quote-style 1
+  "Auto-quoting style."
+  :type '(choice (const :tag "Auto-quotes with double quote" 1)
+                 (const :tag "Auto-quotes with single quote" 2))
+  :group 'emmet)
+
 (defcustom emmet-indent-after-insert t
   "Indent region after insert?"
   :type 'boolean


### PR DESCRIPTION
This allows using single or double quotes in html, jsx and tsx. It is also a possible solution to #90.
```lisp
(setq emmet-html-auto-quote-style 1) ;; default double quote
(setq emmet-html-auto-quote-style 2) ;; or single quote
```
And in code:
```html
<a href=""></a>
<a href=''></a>
```